### PR TITLE
Feature/converter bits bytes

### DIFF
--- a/converter-bits-bytes/converter-bits-bytes.c
+++ b/converter-bits-bytes/converter-bits-bytes.c
@@ -1,17 +1,21 @@
 #include <stdio.h>
 #include <stdlib.h> 
 
+// Função que realiza as conversões de bits para outras unidades
 void converterBitsBytes() {
     double bits, bytes, kilobytes, megabytes, gigabytes;
 
+    // Solicita ao usuário o valor em bits
     printf("Digite o valor em bits: ");
     scanf("%lf", &bits);
 
-    bytes = bits / 8;
-    kilobytes = bytes / 1024;
-    megabytes = kilobytes / 1024;
-    gigabytes = megabytes / 1024;
+    // Conversões: de bits para bytes, kilobytes, megabytes e gigabytes
+    bytes = bits / 8; // 1 byte = 8 bits
+    kilobytes = bytes / 1024; // 1 kilobyte = 1024 bytes
+    megabytes = kilobytes / 1024; // 1 megabyte = 1024 kilobytes
+    gigabytes = megabytes / 1024; // 1 gigabyte = 1024 megabytes
 
+    // Exibe os resultados das conversões
     printf("Conversões:\n");
     printf("Bytes: %.2lf\n", bytes);
     printf("Kilobytes (KB): %.10lf\n", kilobytes);
@@ -20,8 +24,14 @@ void converterBitsBytes() {
 }
 
 int main() {
+    // Define a codificação para UTF-8, garantindo suporte a caracteres especiais
     system("chcp 65001 > nul"); 
+
+    // Exibe o cabeçalho do programa
     printf("Conversor de Bits e Bytes\n\n");
+
+    // Chama a função de conversão
     converterBitsBytes();
-    return 0;
+
+    return 0; // Indica que o programa terminou com sucesso
 }

--- a/converter-bits-bytes/converter-bits-bytes.c
+++ b/converter-bits-bytes/converter-bits-bytes.c
@@ -33,5 +33,7 @@ int main() {
     // Chama a função de conversão
     converterBitsBytes();
 
+    system("pause");
+    
     return 0; // Indica que o programa terminou com sucesso
 }


### PR DESCRIPTION
Alterações realizadas:

Adicionado: #include <stdlib.h>
A biblioteca foi incluída porque as funções system() usadas no programa (como system("pause") e system("chcp 65001 > nul")) fazem parte desta biblioteca. Sem ela, o compilador não reconheceria as chamadas a system().

Adicionado: system("chcp 65001 > nul");
Este comando configura o terminal para suportar caracteres UTF-8, evitando problemas de exibição de caracteres especiais. O parâmetro > nul oculta a saída do comando no terminal.

Adicionado: system("pause");
Este comando pausa a execução do programa até que o usuário pressione uma tecla, impedindo o fechamento imediato do terminal em sistemas Windows. Isso garante que o usuário possa visualizar a saída do programa antes de fechar o terminal.