### PR TITLE
Correções ortográficas e padronização de biblioteca

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+nul
 *.exe
 .vscode
 **/output/
+conversor

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Atividade de Depuração e Versionamento
+# Depuração e Versionamento no EmbarcaTech
 
 ## 💡 O que é este projeto?
 
-Este é um software para converter unidades de medida utilizado para praticar depuração e versionamento de projetos em C.
+Este é um software escrito em C para converter unidades de medida. Utilizado para praticar depuração e versionamento de projetos no EmbarcaTech.
 
 ## 🔎 Quais recursos estão disponíveis?
 

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Implementado por [Edeilton Oliveira](https://www.linkedin.com/in/edeiltonso/).
 
 O conversor de unidades de comprimento é uma funcionalidade que permite o usuário converter 3 diferentes tipos de medidas, sendo elas: metro, centímetro e milímetro. A utilização da funcionalidade se dá a partir de quatro passos simples:
 
-1° Selecionar a opção "conversor de comprimento" no menu principal;
-2° Selecionar o tipo de conversão(metros, centímetros ou milímetros);
-3° Fornecer o valor da medida que será convertida;
-4° Apresentação da conversão.
+1. Selecionar a opção "conversor de comprimento" no menu principal;
+2. Selecionar o tipo de conversão(metros, centímetros ou milímetros);
+3. Fornecer o valor da medida que será convertida;
+4. Apresentação da conversão.
 
-Implementado por [Rogerio Silva Palafoz Junior - Kuroikenshiga](https://github.com/Kuroikenshiga)
+Implementado por [Rogerio Silva Palafoz Junior - Kuroikenshiga](https://github.com/Kuroikenshiga).
 
 ### Conversor de unidades de armazenamento da computação
 
@@ -30,9 +30,9 @@ O conversor de unidades de armazenamento de dados permite a conversão de bits p
 - **Bits para bytes** (1 byte = 8 bits);
 - **Bytes para kilobytes** (1 KB = 1024 bytes);
 - **Kilobytes para megabytes** (1 MB = 1024 KB);
-- **Megabytes para gigabytes** (1 GB = 1024 MB);
+- **Megabytes para gigabytes** (1 GB = 1024 MB).
 
-Implementado por [Edemir Carvalho](https://github.com/demyshow)
+Implementado por [Edemir Carvalho](https://github.com/demyshow).
 
 ### Conversor de unidades de tempo
 
@@ -40,46 +40,61 @@ O conversor de tempo permite que você converta as unidades de tempo mais utiliz
 
 É possível converter:
 
-- 1 - Segundos para minutos;
-- 2 - Segundos para horas;
-- 3 - Minutos para segundos;
-- 4 - Minutos para horas;
-- 5 - Horas para segundos;
-- 6 - Horas para minutos.
+- Segundos para minutos;
+- Segundos para horas;
+- Minutos para segundos;
+- Minutos para horas;
+- Horas para segundos;
+- Horas para minutos.
 
-Cada conversão possui uma precisão de 5 decimais 
+Cada conversão possui uma precisão de 5 casas decimais.
 
-Implementado por [Gustavo Oliveira Alves](https://github.com/Astorolus-11)
+Implementado por [Gustavo Oliveira Alves](https://github.com/Astorolus-11).
 
 ### Conversor de unidades de velocidade
 
 O arquivo `conv-vel.c`, implementa um conversor de velocidade em linguagem C. Ele permite converter valores entre três diferentes unidades de medida de velocidade:
 
-- Metros por Segundo (m/s)
-- Quilômetros por Hora (km/h)
-- Milhas por Hora (mph)
+- Metros por Segundo (m/s);
+- Quilômetros por Hora (km/h);
+- Milhas por Hora (mph).
 
 A aplicação é interativa, solicitando ao usuário as unidades de entrada e saída, bem como o valor que deseja converter. Tem como funcionalidades a seleção da unidade de entrada, seleção da unidade de saída, além do cálculo de conversão, baseado nas constantes de conversão pré-definidas e claro a exibição do resultado exibindo o valor convertido, formatado com duas casas decimais.
 
-Implementado por [Valnei Sousa](https://www.linkedin.com/in/valnei-sousa-45a831286/)
+Implementado por [Valnei Sousa](https://www.linkedin.com/in/valnei-sousa-45a831286/).
 
 ### Conversor de unidades de massa
 
 O arquivo `conv-massa.c` implementa um menu no qual o usuário pode realizar conversões de unidades de medidas de massa. Ao escolher uma unidade de medida de entrada e de saída o usuário terá printado na tela o valor convertido na unidade de medida selecionada. Após realizar a conversão o usuário pode decidir se deseja permanecer convertendo outros valores ou se deseja voltar ao menu principal.
 
-Implementado por [Cibelle Sousa Rodrigues](https://github.com/CibelleSousa)
+Implementado por [Cibelle Sousa Rodrigues](https://github.com/CibelleSousa).
 
 ### Conversor de unidades de volume
 
-O conversor de unidades de volume realiza conversões entre diferentes unidades de medida volumétrica, como quilolitros (kL), hectolitros (hL), decalitros (daL), litros (L), decilitros (dL), centilitros (cL) e mililitros (mL).
+O conversor de unidades de volume realiza conversões entre diferentes unidades de medida volumétrica:
 
-A aplicação utiliza constantes pré-definidas e exibe instruções durante todo o processo, incluindo possíveis mensagens de erros.
+- Quilolitros (kL);
+- Hectolitros (hL);
+- Decalitros (daL);
+- Litros (L);
+- Decilitros (dL);
+- Centilitros (cL);
+- Mililitros (mL).
 
-Implementado por [Joabis Jr.](https://github.com/Joabis25)
+A aplicação utiliza constantes pré-definidas e exibe instruções durante todo o processo, incluindo possíveis mensagens de erro.
+
+Implementado por [Joabis Jr](https://github.com/Joabis25).
+
+## 🛠 Quais são os pré-requisitos?
+
+1. Se você estiver no Windows, instale o [MinGW](https://sourceforge.net/projects/mingw/) (GCC e Make);
+2. Baixe o repositório com `git clone`.
+
+No Linux, GCC e Make normalmente já estão disponíveis de forma nativa.
 
 ## 💻 Como executar o programa no Windows?
 
-Na raiz do projeto, execute uma das sequências de comandos:
+Acesse a pasta raiz do projeto clonado e execute uma das sequências de comandos:
 
 ### Com o GCC
 1. `gcc .\index.c .\conv-comp\conv-comp.c .\conv-tempo\conv-tempo.c .\conv-vel\conv-vel.c .\conv-dados\conv-dados.c .\conv-massa\conv-massa.c .\conv-volume\conv-volume.c -o conversor`
@@ -91,7 +106,7 @@ Na raiz do projeto, execute uma das sequências de comandos:
 
 ## 🐧 Como executar o programa no Linux?
 
-Na raiz do projeto, execute uma das sequências de comandos:
+Acesse a pasta raiz do projeto clonado e execute uma das sequências de comandos:
 
 ### Com o GCC
 1. `gcc ./index.c ./conv-comp/conv-comp.c ./conv-tempo/conv-tempo.c ./conv-vel/conv-vel.c ./conv-dados/conv-dados.c ./conv-massa/conv-massa.c ./conv-volume/conv-volume.c -o conversor`

--- a/conv-comp/conv-comp.c
+++ b/conv-comp/conv-comp.c
@@ -1,24 +1,24 @@
 #include <stdio.h>
-#include <locale.h>
 #include <stdlib.h>
 
 #include "conv-comp.h"
 
-// Convers�o de metros
+// Conversao de metros
 float metroParaCentimetro(float medidaMetro);
 float metroParaMilimetro(float medidaMetro);
 
-// Convers�o de centimetros
+// Conversao de centimetros
 float centimetroParaMetro(float medidaCentimetro);
 float centimetroParaMilimetro(float medidaCentimetro);
 
-// Convers�o de milimetros
+// Conversao de milimetros
 float milimetroParaMetro(float medidaMilimetro);
 float milimetroParaCentimetro(float medidaMilimetro);
 
 int indexComprimento()
 {
-    setlocale(LC_ALL, "Portuguese");
+    system("chcp 65001 > nul");
+
     int opcao = 0;
     float medida = 0;
 
@@ -27,18 +27,18 @@ int indexComprimento()
         printf("\nConversor de medidas");
         printf("\n---------------------------------------");
 
-        printf("\nInforme o tipo de convers�o\n\n1 - Metros para cent�metros\n2 - Metros para mil�metros\n3 - Cent�metros para metro\n4 - Cent�metro para mil�metro\n5 - Mil�metro para metro\n6 - M�limetro para cent�metro\n0 - Sair\n");
+        printf("\nInforme o tipo de conversão\n\n1 - Metros para centímetros\n2 - Metros para milímetros\n3 - Centímetros para metro\n4 - Centímetro para milímetro\n5 - Milímetro para metro\n6 - Mílimetro para centímetro\n0 - Sair\n");
 
         scanf("%d",&opcao);
         fflush(stdin);
 
         if(opcao > 6 || opcao < 0){
-            printf("\nop��o invalida. Por favor selecione uma op��o de convers�o apropriada");
+            printf("\nOpção inválida. Por favor selecione uma opção de conversão apropriada.");
             continue;
         }
         if(opcao == 0)break;
 
-        printf("Informe o valor da medida para realizar a convers�o: ");
+        printf("Informe o valor da medida para realizar a conversão: ");
         
         scanf("%f",&medida);
         fflush(stdin);
@@ -46,27 +46,27 @@ int indexComprimento()
         switch (opcao)
         {
         case 1:
-            printf("\n%.2f metro(s) � o equivalente a %.2f cent�metro(s)",medida,metroParaCentimetro(medida));
+            printf("\n%.2f metro(s) é o equivalente a %.2f centímetro(s)",medida,metroParaCentimetro(medida));
         break;
 
         case 2:
-            printf("\n%.2f metro(s) � o equivalente a %.2f mil�metro(s)",medida,metroParaMilimetro(medida));
+            printf("\n%.2f metro(s) é o equivalente a %.2f milímetro(s)",medida,metroParaMilimetro(medida));
         break;
 
         case 3:
-            printf("\n%.2f cent�metro(s) � o equivalente a %.2f metro(s)",medida,centimetroParaMetro(medida));
+            printf("\n%.2f centímetro(s) é o equivalente a %.2f metro(s)",medida,centimetroParaMetro(medida));
         break;
 
         case 4:
-            printf("\n%.2f cent�metro(s) � o equivalente a %.3f mil�metro(s)",medida,centimetroParaMilimetro(medida));
+            printf("\n%.2f centímetro(s) é o equivalente a %.3f milímetro(s)",medida,centimetroParaMilimetro(medida));
         break;
 
         case 5:
-            printf("\n%.2f mil�metro(s) � o equivalente a %.3f metro(s)",medida,milimetroParaMetro(medida));
+            printf("\n%.2f milímetro(s) é o equivalente a %.3f metro(s)",medida,milimetroParaMetro(medida));
         break;
         
         case 6:
-            printf("\n%.2f mil�metro(s) � o equivalente a %.2f cent�metro(s)",medida,milimetroParaCentimetro(medida));
+            printf("\n%.2f milímetro(s) é o equivalente a %.2f centímetro(s)",medida,milimetroParaCentimetro(medida));
         break;
         
         }
@@ -76,7 +76,7 @@ int indexComprimento()
         return 0;
 }
 
-// Convers�o de metros
+// Conversao de metros
 float metroParaCentimetro(float medidaMetro)
 {
     return medidaMetro * 100;
@@ -86,7 +86,7 @@ float metroParaMilimetro(float medidaMetro)
     return medidaMetro * 1000;
 }
 
-// Convers�o de centimetros
+// Conversao de centimetros
 float centimetroParaMetro(float medidaCentimetro)
 {
     return medidaCentimetro / 100;
@@ -96,7 +96,7 @@ float centimetroParaMilimetro(float medidaCentimetro)
     return medidaCentimetro * 10;
 }
 
-// Convers�o de milimetros
+// Conversao de milimetros
 float milimetroParaMetro(float medidaMilimetro)
 {
     return medidaMilimetro / 1000;

--- a/conv-tempo/conv-tempo.c
+++ b/conv-tempo/conv-tempo.c
@@ -1,18 +1,18 @@
 #include <stdio.h>
-#include <locale.h>
+#include <stdlib.h>
 
 #include "conv-tempo.h"
 
 int indexTempo(){
 
-    setlocale(LC_ALL,"portuguese");
+    system("chcp 65001 > nul");
     int opc;
     double segundos,minutos,horas;
 
 do{
-    printf("Qual tipo de conversao de tempo deseja fazer?\n");
+    printf("Qual tipo de conversão de tempo deseja fazer?\n");
     printf("1 - Segundos para minutos.\n");
-    printf("2 - Segundos para Horas.\n");
+    printf("2 - Segundos para horas.\n");
     printf("3 - Minutos para segundos.\n");
     printf("4 - Minutos para horas.\n");
     printf("5 - Horas para segundos.\n");
@@ -21,7 +21,7 @@ do{
     scanf("%d",&opc);
     fflush(stdin);
 
-    switch (opc){ //cases das op��es
+    switch (opc){ //cases das opções
 
         case 1:{
             printf("Digite quantos segundos:\n");
@@ -77,12 +77,12 @@ do{
             break;
         }
         case 0:{
-            printf("Fim da convers�o\n");
+            printf("Fim da conversão\n");
             break;
         }
 
         default:{
-          printf("Op��o inv�lida! Digite novamente.\n");
+          printf("Opção inválida! Digite novamente.\n");
         break;
         }
         

--- a/conv-vel/conv-vel.c
+++ b/conv-vel/conv-vel.c
@@ -4,7 +4,7 @@
 #include "conv-vel.h"
 
 int indexVelocidade() {
-    system("chcp 65001 >nul");
+    system("chcp 65001 > nul");
     int opcaoini, opcaofim;
     float vms = 0.0, vmphs = 0.0, vkmhs = 0.0, convfim = 0.0;
     #define mstomph 2.2369; // Constante de Conversão de Metros por Segundo Para Milhas Por Hora

--- a/conv-volume/conv-volume.c
+++ b/conv-volume/conv-volume.c
@@ -1,5 +1,5 @@
 #include <stdio.h>
-#include <locale.h>
+#include <stdlib.h>
 
 void exibirOpcoesGerais();
 void exibirOpcoesConversao(int tipo);
@@ -9,7 +9,7 @@ float obterValor(const char* unidade);
 void volume() {
     int conversores = 0;
 
-    setlocale(LC_ALL, "Portuguese");
+    system("chcp 65001 > nul");
     do {
         exibirOpcoesGerais();
         printf("Escolha uma opção (ou 8 para sair): ");
@@ -19,7 +19,7 @@ void volume() {
         if (conversores >= 1 && conversores <= 7) {
             int valor;
             exibirOpcoesConversao(conversores);
-            printf("Escolha uma conversao (ou 0 para voltar): ");
+            printf("Escolha uma conversão (ou 0 para voltar): ");
             scanf("%d", &valor);
             fflush(stdin);
 
@@ -27,7 +27,7 @@ void volume() {
                 realizarConversao(conversores, valor);
             }
         } else if (conversores != 8) {
-            printf("Numero invalido. Tente novamente.\n");
+            printf("Número inválido. Tente novamente.\n");
         }
 
     } while (conversores != 8);
@@ -41,7 +41,7 @@ void exibirOpcoesGerais() {
 }
 
 void exibirOpcoesConversao(int tipo) {
-    printf("\nOpcoes de conversao:\n");
+    printf("\nOpções de conversão:\n");
     switch (tipo) {
         case 1:
             printf("1-qL para hL\n2-qL para daL\n3-qL para L\n4-L para qL\n");
@@ -65,7 +65,7 @@ void exibirOpcoesConversao(int tipo) {
             printf("1-mL para cL\n2-mL para dL\n3-mL para L\n");
             break;
         default:
-            printf("Opcao invalida.\n");
+            printf("Opção inválida.\n");
     }
 }
 
@@ -112,7 +112,7 @@ void realizarConversao(int tipo, int opcao) {
 
         // Outros casos podem ser implementados seguindo o mesmo padr�o
         default:
-            printf("Conversao invalida.\n");
+            printf("Conversão inválida.\n");
     }
 }
 


### PR DESCRIPTION
### Esse PR:

1. define a função `system()` da `stdlib.h` como padrão para garantir a exibição de caracteres acentuados;
2. complementa arquivo `.gitignore` com saídas de compilação do Linux;
3. substitui caracteres "�" pelas suas versões legíveis;
4. adiciona seção de pré-requisitos ao README;
5. melhora escrita de textos da documentação.